### PR TITLE
Arguments, result and multi-line docstrings.

### DIFF
--- a/src/fspx/autofortran_directive.py
+++ b/src/fspx/autofortran_directive.py
@@ -104,14 +104,14 @@ class AutoFortranDirective(Directive):
         # Handle arguments within parentheses
         if args:
             params = addnodes.desc_parameterlist()
-            # Add only arguments with the attribute intent(in, out or inout).
+            # Add only arguments with the attribute intent.
             for arg_name, arg_info in args.items():
                 if "intent" in arg_info["attributes"]:
                     param = addnodes.desc_parameter(text=f"{arg_name}")
                     params += param
             sig += params
         
-        # Add result such as function_signature(args)->result
+        # Add result 
         if result:
             res = addnodes.desc_returns(text=f"{result:s}")
             sig += res

--- a/src/fspx/fortran_parser.py
+++ b/src/fspx/fortran_parser.py
@@ -134,9 +134,6 @@ def extract_arguments(list, docmarker:str="!>"):
         attrs = intrinsic_type
         if Attr_List:
             attrs = intrinsic_type + ', ' + Attr_List.string
-        # filter variables with no intent declaration
-        if not 'intent' in attrs:
-            continue
         Entity_List = get_child( list[2*idx] , fp2003.Entity_Decl_List )
         for arg in Entity_List.children:
             args_doc[arg.string] = {


### PR DESCRIPTION
Do not filter intent attribute in the parser.
It might be better to filter the intent  attribute for the parsed arguments in
the Directive. This way, the function result variable will be available
and the documentation will work both function declarations:

1. type of the returned value in the function header:

```fortran
   real(real64) func_name(args)result(res)
   ...
   end func_name
```

2. type of the returned value in the function body:

```fortran
   func_name(args)result(res)
   ...
   real(real64)::res
   ...
   end func_name
```

I'm sorry,  I pushed to your repo directly. 